### PR TITLE
Add basic CI workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on pushes and pull requests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689999573a388324abb98a8d8b558752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a continuous integration workflow using GitHub Actions that runs on pushes and pull requests to the main branch.
  * Automatically sets up Python 3.11, installs dependencies, and runs the test suite with pytest on Ubuntu runners.
  * Enhances reliability by standardizing automated test execution across environments.
  * Provides an initial, streamlined CI pipeline as a foundation for future improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->